### PR TITLE
Set db_version after creation

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -62,6 +62,7 @@ function setup_db() {
 				tweet_id, path
 			);
 		");
+		meta_set('db_version', 3);
 	} else {
 		$db = new PDO("sqlite:$filename");
 		if (! $db) {


### PR DESCRIPTION
Otherwise it immediately tries to migrate and fails as the "new"
columns already exist

Results in a 500 error when trying to access the app for the first time